### PR TITLE
No longer creates and adds a new TreeNode with val set to null.

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,27 +43,31 @@ function TreeNode(val) {
 // https://leetcode.com/faq/#binary-tree
 function createTree(arr) {
   if (!arr.length || arr[0] === null) return null;
-  var len = arr.length;
-
+  
   var res = new TreeNode(arr[0]);
   var nodes = arr.slice(1);
   var children = [res];
-  var current = res;
   while(children.length) {
-    current = children.shift();
+    let current = children.shift();
 
     if (!current || current.val === null) {
       continue;
     }
 
     if (nodes.length) {
-      current.left = new TreeNode(nodes.shift());
-      children.push(current.left);
+      let val = nodes.shift();
+      if (val) {
+        current.left = new TreeNode(val);
+        children.push(current.left);
+      }
     }
 
     if (nodes.length) {
-      current.right = new TreeNode(nodes.shift())
-      children.push(current.right);
+      let val = nodes.shift();
+      if (val) {
+        current.right = new TreeNode(val);
+        children.push(current.right);
+      }
     }
   }
 


### PR DESCRIPTION
For example, for `[1,null,2]` the resulting tree is now...

![image](https://cloud.githubusercontent.com/assets/7350928/17035423/22d25ea8-4fc2-11e6-8963-c775ad2ed67c.png)

...and not...

![image](https://cloud.githubusercontent.com/assets/7350928/17035434/2d0c95be-4fc2-11e6-88f1-2c63d1e7ddf4.png)

Also, removed the unused var, `len`. And the redundant initialization, `var current = res;`
